### PR TITLE
Replace URL health check with ping health check

### DIFF
--- a/HousingRepairsSchedulingApi/HousingRepairsSchedulingApi.csproj
+++ b/HousingRepairsSchedulingApi/HousingRepairsSchedulingApi.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Ardalis.GuardClauses" Version="3.3.0" />
     <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="6.0.2" />
+    <PackageReference Include="AspNetCore.HealthChecks.Network" Version="6.0.1" />
     <PackageReference Include="HACT.Dtos" Version="1.0.0" />
     <PackageReference Include="HousingRepairsOnline.Authentication" Version="1.1.0" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />

--- a/HousingRepairsSchedulingApi/Startup.cs
+++ b/HousingRepairsSchedulingApi/Startup.cs
@@ -72,9 +72,9 @@ namespace HousingRepairsSchedulingApi
             });
 
             var address = Configuration.GetSection(nameof(DrsOptions))[DrsOptionsApiAddressConfigurationKey];
-            var addressHost = new Uri(address).GetLeftPart(UriPartial.Authority);
+            var addressHost = new Uri(address).Host;
             services.AddHealthChecks()
-                .AddUrlGroup(new Uri(addressHost), "DRS API Url");
+                .AddPingHealthCheck(options => options.AddHost(addressHost, 1000), name: "DRS Host Ping");
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.


### PR DESCRIPTION
Using DRS API address URL for health check isn't appropriate for Azure as DRS will redirect to the login page and Azure doesn't follow 302 redirects (see note [here](https://docs.microsoft.com/en-us/azure/app-service/monitor-instances-health-check#what-app-service-does-with-health-checks))